### PR TITLE
fix rustls no process-level CryptoProvider available issue

### DIFF
--- a/src/raw_client.rs
+++ b/src/raw_client.rs
@@ -381,6 +381,8 @@ impl RawClient<ElectrumSslStream> {
     ) -> Result<Self, Error> {
         use std::convert::TryFrom;
 
+        #[cfg(feature = "use-rustls")]
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let builder = ClientConfig::builder();
 
         let config = if validate_domain {


### PR DESCRIPTION
As reported by @nicbus on telegram, running this code:
```rust
let indexer_url = "ssl://electrum.iriswallet.com:50013";
let electrum_config = electrum::Config::builder()
    .timeout(Some(4))
    .build();
let electrum_client = electrum::Client::from_config(indexer_url, electrum_config);
assert!(electrum_client.is_ok());
```
in a project that depends only on:
```
bp-electrum = { version = "=0.11.0-beta.8", default-features = false, features = [
    "proxy",
    "use-rustls",
] }
bp-esplora = { version = "=0.11.0-beta.8", default-features = false, features = [
    "blocking",
] }
```
causes the following panic on line 5:
```
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/crypto/mod.rs:259:14:
no process-level CryptoProvider available -- call CryptoProvider::install_default() before this point
```

This error was also found when adding the mempool indexer but the solution proposed in https://github.com/BP-WG/bp-wallet/pull/50#issuecomment-2228726756 is not valid anymore.

This PR fixes this issue by explicitly selecting a process-level provider before calling `ClientConfig::builder()`, as documented in https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider.
